### PR TITLE
Fix missing Tone.js reference in dashboard

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -2,6 +2,14 @@ import streamlit as st
 from utils import read_sheet, kpi_value
 
 st.set_page_config(page_title="Dashboard Vendedor360", page_icon="D", layout="wide")
+
+# Carga la librería Tone.js para evitar errores de referencia en el navegador.
+st.markdown(
+    """
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/tone/14.8.39/Tone.min.js"></script>
+    """,
+    unsafe_allow_html=True,
+)
 st.title("Dashboard Unificado - Vendedor360 (MVP)")
 
 inv = read_sheet("Inventario")


### PR DESCRIPTION
## Summary
- Inject Tone.js from CDN to avoid `Tone is not defined` error in the browser

## Testing
- `pytest`
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68c4d911caa0832b9a84c4c0a27f6036